### PR TITLE
Add CycleGAN discriminator model

### DIFF
--- a/net/invoke/train.py
+++ b/net/invoke/train.py
@@ -29,8 +29,6 @@ def train_horse2zebra_model(_context, config_path):
 
     icecream.ic(data.shape)
 
-    generated_right = cycle_gan.left_collection_generator.predict(data, verbose=0)
-    generated_left = cycle_gan.right_collection_generator.predict(generated_right, verbose=0)
+    output = cycle_gan.collection_a_discriminator.predict(data, verbose=0)
 
-    icecream.ic(generated_right.shape)
-    icecream.ic(generated_left.shape)
+    icecream.ic(output.shape)

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -17,3 +17,19 @@ def test_cyclegan_generator():
     actual = net.ml.GeneratorBuilder().get_model().predict(input_data, verbose=0)
 
     assert actual.shape == input_data.shape
+
+
+def test_cyclegan_discriminator():
+    """
+    Test cyclegan discriminator create data of the same shape as input data
+    """
+
+    input_data = np.ones((4, 256, 256, 3))
+
+    actual = net.ml.DiscriminatorBuilder().get_model().predict(input_data, verbose=0)
+
+    # Assert batch dimension remains the same
+    assert actual.shape[0] == input_data.shape[0]
+
+    # Assert output has 1 channel
+    assert actual.shape[-1] == 1


### PR DESCRIPTION
This commit adds the implementation of the CycleGAN discriminator model. The discriminator is responsible for distinguishing between real and generated images. It uses a series of convolutional layers with leaky ReLU activation and batch normalization. The output is a single-channel image.